### PR TITLE
Add support for Wasm targets

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -20,4 +20,3 @@ jobs:
       ci_tools_version: main
       extension_name: capi_quack
       extra_toolchains: python3
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
+option(DUCKDB_WASM_EXTENSIONS "Whether compiling for Wasm target" OFF)
 
 ###
 # Configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,12 @@ set(EXTENSION_SOURCES
         src/add_numbers.c
         src/capi_quack.c
 )
-add_library(${EXTENSION_NAME} SHARED ${EXTENSION_SOURCES})
+
+if (DUCKDB_WASM_EXTENSION)
+	add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
+else()
+	add_library(${EXTENSION_NAME} SHARED ${EXTENSION_SOURCES})
+endif()
 
 # Hide symbols
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
Depends on https://github.com/duckdb/extension-ci-tools/pull/113 being merged, failure currently expected.