### PR TITLE
Invoke CI only on main branch

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -4,6 +4,7 @@
 name: Main Extension Distribution Pipeline
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
See https://github.com/duckdb/extension-template-rs/pull/23 for more context.

Briefly, the current setting is not suitable for doing a pull request based development on a single repository; when a developer pushes a commit to a pull request, it doubly invokes the CI both for `push` event and `pull_request` event. This change fixes it by limiting the `push` event to the `main` branch.